### PR TITLE
 Add New YNO games to discordRpcUtils

### DIFF
--- a/src/scripts/discordRpcUtils.js
+++ b/src/scripts/discordRpcUtils.js
@@ -25,6 +25,9 @@ const mappedIcons = [
   "oversomnia",
   "yumetsushin",
   "nostalgic",
+  "oneshot",
+  "if",
+  "unnacomplished",
   "collectiveunconscious",
 ];
 


### PR DESCRIPTION
* Add Oneshot, If, and Unnacomplished to discordRpcUtils

NOTE: This is not intended to be merged unless the icons for the above games are added to the Discord RPC application. Playing one of the games above will throw an annoying error about a missing asset if you close the window with them running due to the missing asset. If said Discord application is no longer accessible by the new fork owner this should probably be redone at some point...